### PR TITLE
Update locator.py

### DIFF
--- a/backtrader/plot/locator.py
+++ b/backtrader/plot/locator.py
@@ -222,9 +222,6 @@ class AutoDateLocator(ADLocator):
             locator = MicrosecondLocator(interval, tz=self.tz)
 
         locator.set_axis(self.axis)
-
-        locator.set_view_interval(*self.axis.get_view_interval())
-        locator.set_data_interval(*self.axis.get_data_interval())
         return locator
 
 


### PR DESCRIPTION
 '''      
 locator.set_view_interval(*self.axis.get_view_interval())
 locator.set_data_interval(*self.axis.get_data_interval())
'''
set_view_interval and set data_interval had been deprecated after matplotlib  3.6.x